### PR TITLE
Fix deprecation warnings

### DIFF
--- a/roles/aide/tasks/main.yml
+++ b/roles/aide/tasks/main.yml
@@ -6,8 +6,8 @@
   vars:
     params:
       files:
-        - "{{ ansible_distribution | lower }}.yml"
-        - "{{ ansible_os_family | lower }}.yml"
+        - "{{ ansible_facts['distribution'] | lower }}.yml"
+        - "{{ ansible_facts['os_family'] | lower }}.yml"
         - default.yml
       paths:
         - '{{ playbook_dir }}/vars'
@@ -29,7 +29,7 @@
   vars:
     params:
       files:
-        - "{{ ansible_os_family | lower }}.yml"
+        - "{{ ansible_facts['os_family'] | lower }}.yml"
       paths:
         - "{{ role_path }}/tasks"
 

--- a/roles/auditd/tasks/main.yml
+++ b/roles/auditd/tasks/main.yml
@@ -6,8 +6,8 @@
   vars:
     params:
       files:
-        - "{{ ansible_distribution | lower }}.yml"
-        - "{{ ansible_os_family | lower }}.yml"
+        - "{{ ansible_facts['distribution'] | lower }}.yml"
+        - "{{ ansible_facts['os_family'] | lower }}.yml"
       paths:
         - '{{ playbook_dir }}/vars'
         - '{{ role_path }}/vars'

--- a/roles/fail2ban/defaults/main.yml
+++ b/roles/fail2ban/defaults/main.yml
@@ -82,7 +82,7 @@ fail2ban_mode: null
 fail2ban_destemail: "root@localhost"
 
 # sender email address
-fail2ban_sender: "root@{{ ansible_fqdn }}"
+fail2ban_sender: "root@{{ ansible_facts['fqdn'] }}"
 
 # email mta
 fail2ban_mta: null

--- a/roles/fail2ban/tasks/main.yml
+++ b/roles/fail2ban/tasks/main.yml
@@ -6,8 +6,8 @@
   vars:
     params:
       files:
-        - "{{ ansible_distribution | lower }}.yml"
-        - "{{ ansible_os_family | lower }}.yml"
+        - "{{ ansible_facts['distribution'] | lower }}.yml"
+        - "{{ ansible_facts['os_family'] | lower }}.yml"
         - default.yml
       paths:
         - '{{ playbook_dir }}/vars'

--- a/roles/openssh_server/tasks/main.yml
+++ b/roles/openssh_server/tasks/main.yml
@@ -6,9 +6,9 @@
   vars:
     params:
       files:
-        - "{{ ansible_distribution | lower }}_{{ ansible_distribution_major_version }}.yml"
-        - "{{ ansible_distribution | lower }}.yml"
-        - "{{ ansible_os_family | lower }}.yml"
+        - "{{ ansible_facts['distribution'] | lower }}_{{ ansible_distribution_major_version }}.yml"
+        - "{{ ansible_facts['distribution'] | lower }}.yml"
+        - "{{ ansible_facts['os_family'] | lower }}.yml"
         - default.yml
       paths:
         - '{{ playbook_dir }}/vars'
@@ -116,7 +116,7 @@
   vars:
     params:
       files:
-        - "{{ ansible_os_family | lower }}.yml"
+        - "{{ ansible_facts['os_family'] | lower }}.yml"
 
 - name: Configure openssh server
   ansible.builtin.template:

--- a/roles/openssh_server/tasks/redhat.yml
+++ b/roles/openssh_server/tasks/redhat.yml
@@ -11,8 +11,8 @@
   vars:
     sysconfig_params:
       files:
-        - "{{ ansible_os_family | lower }}_{{ ansible_distribution_major_version }}/sshd.sysconfig.j2"
-        - "{{ ansible_os_family | lower }}/sshd.sysconfig.j2"
+        - "{{ ansible_facts['os_family'] | lower }}_{{ ansible_facts['distribution_major_version'] }}/sshd.sysconfig.j2"
+        - "{{ ansible_facts['os_family'] | lower }}/sshd.sysconfig.j2"
       paths:
         - "{{ role_path }}/templates"
   become: true

--- a/roles/shadow_utils/tasks/main.yml
+++ b/roles/shadow_utils/tasks/main.yml
@@ -9,8 +9,8 @@
   vars:
     params:
       files:
-        - "{{ ansible_distribution | lower }}.yml"
-        - "{{ ansible_os_family | lower }}.yml"
+        - "{{ ansible_facts['distribution'] | lower }}.yml"
+        - "{{ ansible_facts['os_family'] | lower }}.yml"
       paths:
         - '{{ playbook_dir }}/vars'
         - '{{ role_path }}/vars'

--- a/roles/sudo/tasks/main.yml
+++ b/roles/sudo/tasks/main.yml
@@ -6,8 +6,8 @@
   vars:
     params:
       files:
-        - "{{ ansible_distribution | lower }}.yml"
-        - "{{ ansible_os_family | lower }}.yml"
+        - "{{ ansible_facts['distribution'] | lower }}.yml"
+        - "{{ ansible_facts['os_family'] | lower }}.yml"
         - default.yml
       paths:
         - '{{ playbook_dir }}/vars'

--- a/roles/sysstat/tasks/main.yml
+++ b/roles/sysstat/tasks/main.yml
@@ -6,7 +6,7 @@
   vars:
     params:
       files:
-        - "{{ ansible_os_family | lower }}.yml"
+        - "{{ ansible_facts['os_family'] | lower }}.yml"
         - default.yml
       paths:
         - '{{ playbook_dir }}/vars'
@@ -50,6 +50,6 @@
   vars:
     params:
       files:
-        - "{{ ansible_os_family | lower }}.yml"
+        - "{{ ansible_facts['os_family'] | lower }}.yml"
   tags:
     - always


### PR DESCRIPTION
Fix these deprecation warnings:

> 
> TASK [rbrightling.system.fail2ban : Include distro variables] ***************************************************************************************************
> [WARNING]: Deprecation warnings can be disabled by setting `deprecation_warnings=False` in ansible.cfg.
> [DEPRECATION WARNING]: INJECT_FACTS_AS_VARS default to `True` is deprecated, top-level facts will not be auto injected after the change. This feature will be removed from ansible-core version 2.24.
> Origin: /home/cmatte/.ansible/collections/ansible_collections/rbrightling/system/roles/fail2ban/tasks/main.yml:9:11
> 
> 7     params:
> 8       files:
> 9         - "{{ ansible_distribution | lower }}.yml"
>             ^ column 11
> 
> Use `ansible_facts["fact_name"]` (no `ansible_` prefix) instead.
> 